### PR TITLE
Fix logs being merged in 0th and 1st epoch

### DIFF
--- a/tfwatcher/firebase_helpers.py
+++ b/tfwatcher/firebase_helpers.py
@@ -18,9 +18,9 @@ def write_to_firebase(data: dict, ref_id: str, level: str):
 
 
 def write_in_callback(data: dict, ref_id: str):
-    if data["epoch"]:
+    if data["epoch"] or (data["epoch"] is 0):
         level = "epoch"
-    elif data["batch"]:
+    elif data["batch"] or (data["batch"] is 0):
         level = "batch"
     else:
         level = "prediction"


### PR DESCRIPTION
In this piece of code:

https://github.com/Rishit-dagli/TF-Watcher/blob/2df79c92a1e410f5d4fef698c485626bac0d2381/tfwatcher/firebase_helpers.py#L20-L26

because Python takes `0 == False` logs in epoch 0 are never pushed, they only get pushed when logs in the next satisfying epoch  (according to `schedule`) are about to be pushed and the logs for 2 epochs end up getting merged. A simple fix to this is using the Python property that `0 is not False`.

---

Closes #40 