### PR TITLE
Fix an error with logging for Predict methods

### DIFF
--- a/tfwatcher/callbacks/predict.py
+++ b/tfwatcher/callbacks/predict.py
@@ -25,10 +25,7 @@ class PredictEnd(tf.keras.callbacks.Callback):
         # https://github.com/tensorflow/tensorflow/issues/27491#issuecomment-890887810
         self.time = float(self.end_time - self.start_time)
 
-        data = logs
-        data["epoch"] = False
-        data["batch"] = False
-        data["avg_time"] = self.time
+        data = {"epoch": False, "batch": False, "avg_time": self.time}
 
         write_in_callback(data=data, ref_id=self.ref_id)
 

--- a/tfwatcher/callbacks/predict_batch.py
+++ b/tfwatcher/callbacks/predict_batch.py
@@ -60,10 +60,12 @@ class PredictBatchEnd(tf.keras.callbacks.Callback):
             (self.is_int and ((batch + 1) % self.schedule == 0))
             or (self.is_list and ((batch + 1) in self.schedule))
         ) or (batch == 0):
-            data = logs
-            data["batch"] = batch
-            data["epoch"] = False
-            data["avg_time"] = round(mean(self.times), self.round_time)
+
+            data = {
+                "batch": batch,
+                "epoch": False,
+                "avg_time": round(mean(self.times), self.round_time),
+            }
 
             write_in_callback(data=data, ref_id=self.ref_id)
 


### PR DESCRIPTION
As indicated in #48 logging for the Predict methods was not able to convert the `outputs` from the `logs` which is a TF Tensor to a dictionary. A simple fix would be to use `.numpy()` in eager mode or evaluate in graph model but the current proposed version upon examination seems to be more useful.

---

Closes #48 